### PR TITLE
mDNS: look at the additional records to find IPv4 addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellies-ds9",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Handles communication with the next generation of Shelly devices",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/discovery/mdns.ts
+++ b/src/discovery/mdns.ts
@@ -187,7 +187,7 @@ export class MdnsDeviceDiscoverer extends DeviceDiscoverer {
     let ipAddress: string | null = null;
 
     // find the device IP address among the answers
-    for (const a of response.answers) {
+    for (const a of response.answers.concat(response.additionals)) {
       if (a.type === 'A') {
         ipAddress = a.data;
       }


### PR DESCRIPTION
Some mDNS implementations only return the `PTR` record in response to the PTR query and put other response types (e.g. `A`) in the additionals section.