### PR TITLE
added support for gen3 2pm device

### DIFF
--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -19,3 +19,4 @@ export * from "./shelly-pro-dimmer-2-pm";
 export * from "./shelly-pro-dual-cover-pm";
 export * from "./shelly-plus-dimmer-pm";
 export * from "./shelly-plus-dimmer";
+export * from "./shelly-gen3-2-pm";

--- a/src/devices/shelly-gen3-2-pm.ts
+++ b/src/devices/shelly-gen3-2-pm.ts
@@ -1,0 +1,52 @@
+import { component, Device, MultiProfileDevice } from './base';
+import {
+  BluetoothLowEnergy,
+  Cloud,
+  Cover,
+  Input,
+  Mqtt,
+  OutboundWebSocket,
+  Script,
+  Switch,
+  WiFi,
+} from '../components';
+
+export class ShellyGen32Pm extends MultiProfileDevice {
+  static readonly model: string = "S3SW-002P16EU";
+  static readonly modelName: string = "Shelly 2PM Gen3";
+
+  @component
+  readonly wifi = new WiFi(this);
+
+  @component
+  readonly bluetoothLowEnergy = new BluetoothLowEnergy(this);
+
+  @component
+  readonly cloud = new Cloud(this);
+
+  @component
+  readonly mqtt = new Mqtt(this);
+
+  @component
+  readonly outboundWebSocket = new OutboundWebSocket(this);
+
+  @component
+  readonly cover0 = new Cover(this, 0);
+
+  @component
+  readonly input0 = new Input(this, 0);
+
+  @component
+  readonly input1 = new Input(this, 1);
+
+  @component
+  readonly switch0 = new Switch(this, 0);
+
+  @component
+  readonly switch1 = new Switch(this, 1);
+
+  @component
+  readonly script = new Script(this);
+}
+
+Device.registerClass(ShellyGen32Pm);


### PR DESCRIPTION
Added support for gen3 2-pm device based on shelly-plus-2-pm.

The new functions such as Virtual components, BTHome components or KNX integration are not yet supported (see https://shelly-api-docs.shelly.cloud/gen2/Devices/Gen3/Shelly2PMG3)